### PR TITLE
Refactor c.p.aether to produce and consume maps, and add c.p.lein-aether

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/lein_aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/lein_aether.clj
@@ -1,0 +1,163 @@
+(ns cemerick.pomegranate.lein-aether
+  "Lein dependency spec based interface"
+  (:require
+   [cemerick.pomegranate.aether :as aether]
+   [clojure.java.io :as io]
+   clojure.set))
+
+(defn- group
+  "return the group id of the `group-artifact` symbol"
+  [group-artifact]
+  (or (namespace group-artifact) (name group-artifact)))
+
+;;; conversion from a lein style dependency spec
+(defn- lein-exclusion
+  [[group-artifact & {:keys [extension classifier] :as opts}
+    :as dep-spec]]
+  (merge
+   opts
+   {:group-id (group group-artifact)
+    :artifact-id (name group-artifact)}))
+
+(defn- lein-dependency
+  [[group-artifact version & {:keys [scope optional exclusions]
+                              :as opts
+                              :or {scope "compile"
+                                   optional false}}
+    :as dep-spec]]
+  (merge
+   opts
+   {:group-id (group group-artifact)
+    :artifact-id (name group-artifact)
+    :version version
+    :scope scope
+    :optional optional
+    :exclusions (map lein-exclusion exclusions)}))
+
+;;; conversion to a lein style dependency spec
+(defn- lein-spec
+  "Return a lein-style dependency spec vector for a dependency or exclusion."
+  [{:keys [group-id artifact-id version classifier extension scope optional
+           exclusions]
+    :or {version nil
+         scope "compile"
+         optional false
+         exclusions nil}
+    :as spec}]
+  (let [group-artifact (apply symbol (if (= group-id artifact-id)
+                                       [artifact-id]
+                                       [group-id artifact-id]))]
+    (->
+     (concat [group-artifact]
+             (when version [version])
+             (when (and (seq classifier) (not= "*" classifier))
+               [:classifier classifier])
+             (when (and (seq extension) (not (#{"*" "jar"} extension)))
+               [:extension extension])
+             (when optional [:optional true])
+             (when (not= scope "compile")
+               [:scope scope])
+             (when (seq exclusions)
+               [:exclusions (vec (map lein-spec exclusions))]))
+     vec
+     (with-meta (meta spec)))))
+
+;;; algorithms that consume and produce lein style dependency vectors
+(defn deploy
+    "Deploy the jar-file kwarg using the pom-file kwarg and coordinates kwarg to
+the repository kwarg.
+
+coordinates - [group/name \"version\"]
+
+jar-file - a file pointing to the jar
+
+pom-file - a file pointing to the pom
+
+repository - {name url} | {name settings}
+settings:
+  :url - URL of the repository
+  :snapshots - use snapshots versions? (default true)
+  :releases - use release versions? (default true)
+  :username - username to log in with
+  :password - password to log in with
+  :passphrase - passphrase to log in wth
+  :private-key-file - private key file to log in with
+  :update - :daily (default) | :always | :never
+  :checksum - :fail (default) | :ignore | :warn"
+  [& {:keys [coordinates jar-file pom-file repository] :as options}]
+  (apply
+   aether/deploy
+   :coordinates (lein-dependency coordinates)
+   (apply concat (dissoc options :coordinates))))
+
+(defn install
+  "Install the jar-file kwarg using the pom-file kwarg and coordinates kwarg.
+
+coordinates - [group/name \"version\"]
+
+jar-file - a file pointing to the jar
+
+pom-file - a file pointing to the pom"
+  [& {:keys [coordinates jar-file pom-file] :as options}]
+  (apply
+   aether/install
+   :coordinates (lein-dependency coordinates)
+   (apply concat (dissoc options :coordinates))))
+
+(defn resolve-dependencies
+  "Collects dependencies for the coordinates kwarg, using repositories from the repositories kwarg.
+   Returns a graph of dependencies; each dependency's metadata contains the source Aether
+   Dependency object, and the dependency's :file on disk.  Retrieval of dependencies
+   can be disabled by providing `:retrieve false` as a kwarg.
+
+coordinates - [[group/name \"version\" & settings] ..]
+settings:
+  :scope - the maven scope for the dependency (default \"compile\")
+  :optional? - is the dependency optional? (default \"false\")
+  :exclusions - which sub-dependencies to skip : [group/name & settings]
+    settings:
+      :classifier (default \"*\")
+      :extension  (default \"*\")
+
+repositories - {name url ..} | {name settings ..} (default {\"central\" \"http://repo1.maven.org/maven2/\"}
+settings:
+  :url - URL of the repository
+  :snapshots - use snapshots versions? (default true)
+  :releases - use release versions? (default true)
+  :username - username to log in with
+  :password - password to log in with
+  :passphrase - passphrase to log in wth
+  :private-key-file - private key file to log in with
+  :update - :daily (default) | :always | :never
+  :checksum - :fail (default) | :ignore | :warn"
+  [& {:keys [repositories coordinates retrieve] :as options}]
+  (letfn [(translate-result [[k v]]
+            [(lein-spec k) (when (seq v)
+                             (set (map lein-spec v)))])]
+    (into {}
+          (map translate-result
+               (apply
+                aether/resolve-dependencies
+                :coordinates (map lein-dependency coordinates)
+                (apply concat (dissoc options :coordinates)))))))
+
+(defn dependency-files
+  "Given a dependency graph obtained from `resolve-dependencies`, returns a seq
+   of files from the dependencies' metadata."
+  [graph]
+  (aether/dependency-files graph))
+
+(defn dependency-hierarchy
+  "Returns a dependency hierarchy based on the provided dependency graph
+   (as returned by `resolve-dependencies`) and the coordinates that should
+   be the root(s) of the hierarchy.  Siblings are sorted alphabetically."
+  [root-coordinates dep-graph]
+  (let [hierarchy (for [[root children] (select-keys
+                                         dep-graph root-coordinates)]
+                    [root (dependency-hierarchy children dep-graph)])]
+    (when (seq hierarchy)
+      (into
+       (sorted-map-by
+        #(apply compare
+                (map (comp #'aether/coordinate-string lein-dependency) %&)))
+       hierarchy))))

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -1,111 +1,157 @@
 (ns cemerick.pomegranate.aether-test
   (:require [cemerick.pomegranate.aether :as aether]
             [clojure.java.io :as io])
-  (:use [clojure.test]))
-
-(deftest dependency-roundtripping
-  (are [x] (= x (#'aether/dep-spec (#'aether/dependency x)))
-       '[ring "1.0.0" :optional true]
-       '[com.cemerick/pomegranate "0.0.1" :classifier "sources"]
-       '[demo/demo2 "1.0.0" :exclusions [[demo :classifier "jdk5"]]]))
-
-(def tmp-dir (io/file (System/getProperty "java.io.tmpdir") "pomegranate-test-tmp"))
-(def tmp-remote-repo-dir (.getAbsolutePath (io/file tmp-dir "remote-repo")))
-(def tmp-local-repo-dir (io/file tmp-dir "local-repo"))
-
-(def test-repo {"test-repo" "file://test-repo"})
-(def tmp-remote-repo {"tmp-remote-repo" (str "file://" tmp-remote-repo-dir)})
-
-(defn delete-recursive
-  [dir]
-  (when (.isDirectory dir)
-    (doseq [file (.listFiles dir)]
-      (delete-recursive file)))
-  (.delete dir))
-
-(defn- clear-tmp
-  [f]
-  (delete-recursive (io/file tmp-dir)) (f))
-
-(defn- bind-local-repo
-  [f]
-  (binding [aether/*local-repo* tmp-local-repo-dir]
-    (f)))
+  (:use clojure.test
+        cemerick.pomegranate.test-utils))
 
 (use-fixtures :each clear-tmp bind-local-repo)
 
-(defn file-path-eq [file1 file2]
-  (= (.getAbsolutePath file1)
-     (.getAbsolutePath file2)))
+(deftest dependency-roundtripping
+  (let [default-dep {:extension "jar" :scope "compile"}]
+    (are [x] (= (merge (assoc default-dep :base-version (:version x)) x)
+                (#'aether/dep-spec (#'aether/dependency x)))
+         {:group-id "ring" :artifact-id "ring" :version "1.0.0" :optional true}
+         {:group-id "com.cemerick" :artifact-id "pomegranate" :version "0.0.1"
+          :classifier "sources"}
+         {:group-id "demo" :artifact-id "demo2" :version "1.0.0"
+          :exclusions [{:group-id "demo" :artifact-id "demo"
+                        :classifier "jdk5"}]})))
 
 (deftest live-resolution
-  (let [deps '[[commons-logging "1.1"]]
-        graph '{[javax.servlet/servlet-api "2.3"] nil,
-                [avalon-framework "4.1.3"] nil,
-                [logkit "1.0.1"] nil,
-                [log4j "1.2.12"] nil,
-                [commons-logging "1.1"]
-                #{[javax.servlet/servlet-api "2.3"] [avalon-framework "4.1.3"]
-                  [logkit "1.0.1"] [log4j "1.2.12"]}}
-        hierarchy '{[commons-logging "1.1"]
-                    {[avalon-framework "4.1.3"] nil,
-                     [javax.servlet/servlet-api "2.3"] nil,
-                     [log4j "1.2.12"] nil,
-                     [logkit "1.0.1"] nil}}]
-    (is (= graph (aether/resolve-dependencies :coordinates deps :retrieve false)))
-    (is (not (some #(-> % .getName (.endsWith ".jar")) (file-seq tmp-local-repo-dir))))
-    
+  (let [deps [{:group-id "commons-logging" :artifact-id "commons-logging"
+               :version "1.1"}]
+        graph {{:group-id "javax.servlet" :base-version "2.3"
+                :properties {:constitutes-build-path true
+                             :type "jar" :language "java"}
+                :extension "jar" :version "2.3" :scope "compile"
+                :artifact-id "servlet-api"}
+               nil
+               {:group-id "avalon-framework" :base-version "4.1.3"
+                :properties {:constitutes-build-path true
+                             :type "jar" :language "java"}
+                :extension "jar" :version "4.1.3" :scope "compile"
+                :artifact-id "avalon-framework"}
+               nil
+               {:group-id "logkit" :base-version "1.0.1"
+                :properties {:constitutes-build-path true
+                             :type "jar" :language "java"}
+                :extension "jar" :version "1.0.1" :scope "compile"
+                :artifact-id "logkit"}
+               nil
+               {:group-id "log4j" :base-version "1.2.12"
+                :properties {:constitutes-build-path true
+                             :type "jar" :language "java"}
+                :extension "jar" :version "1.2.12" :scope "compile"
+                :artifact-id "log4j"}
+               nil
+               {:group-id "commons-logging" :base-version "1.1"
+                :extension "jar" :version "1.1"
+                :scope "compile" :artifact-id "commons-logging"}
+               #{{:group-id "log4j" :base-version "1.2.12"
+                  :properties {:constitutes-build-path true
+                               :type "jar" :language "java"}
+                  :extension "jar" :version "1.2.12" :scope "compile"
+                  :artifact-id "log4j"}
+                 {:group-id "javax.servlet" :base-version "2.3"
+                  :properties {:constitutes-build-path true :type "jar"
+                               :language "java"}
+                  :extension "jar" :version "2.3" :scope "compile"
+                  :artifact-id "servlet-api"}
+                 {:group-id "logkit" :base-version "1.0.1"
+                  :properties {:constitutes-build-path true :type "jar"
+                               :language "java"}
+                  :extension "jar" :version "1.0.1" :scope "compile"
+                  :artifact-id "logkit"}
+                 {:group-id "avalon-framework" :base-version "4.1.3"
+                  :properties {:constitutes-build-path true :type "jar"
+                               :language "java"}
+                  :extension "jar" :version "4.1.3" :scope "compile"
+                  :artifact-id "avalon-framework"}}}
+        hierarchy {{:group-id "commons-logging" :base-version "1.1"
+                    :extension "jar" :version "1.1" :scope "compile"
+                    :artifact-id "commons-logging"}
+                   {{:group-id "avalon-framework" :base-version "4.1.3"
+                     :extension "jar" :version "4.1.3" :scope "compile"
+                     :artifact-id "avalon-framework"}
+                    nil
+                    {:group-id "javax.servlet" :base-version "2.3"
+                     :extension "jar" :version "2.3" :scope "compile"
+                     :artifact-id "servlet-api"}
+                    nil
+                    {:group-id "log4j" :base-version "1.2.12" :extension "jar"
+                     :version "1.2.12" :scope "compile" :artifact-id "log4j"}
+                    nil
+                    {:group-id "logkit" :base-version "1.0.1" :extension "jar"
+                     :version "1.0.1" :scope "compile" :artifact-id "logkit"}
+                    nil}}]
+    (is (= graph
+           (aether/resolve-dependencies :coordinates deps :retrieve false)))
+    (is (not (some jar-file? (local-repo-files))))
+
     (doseq [[dep _] (aether/resolve-dependencies :coordinates deps)]
       (is (-> dep meta :file))
       (is (-> dep meta :file .exists)))
-    (is (some #(-> % .getName (.endsWith ".jar")) (file-seq tmp-local-repo-dir)))
-    
+    (is (some jar-file? (local-repo-files)))
+
     (is (= hierarchy (aether/dependency-hierarchy deps graph)))))
 
 (deftest resolve-deps
-  (let [deps (aether/resolve-dependencies :repositories test-repo
-                                          :coordinates
-                                          '[[demo/demo "1.0.0"]])]
+  (let [deps (aether/resolve-dependencies
+              :repositories test-repo
+              :coordinates '[{:group-id "demo" :artifact-id "demo"
+                              :version"1.0.0"}])]
     (is (= 1 (count deps)))
-    (is (= (.getAbsolutePath (io/file tmp-dir "local-repo" "demo" "demo" "1.0.0" "demo-1.0.0.jar"))
+    (is (= (.getAbsolutePath (local-repo-file "demo" "demo" "1.0.0"))
            (.getAbsolutePath (first (aether/dependency-files deps)))))))
 
 (deftest resolve-deps-with-deps
-  (let [deps (aether/resolve-dependencies :repositories test-repo
-                                           :coordinates
-                                           '[[demo/demo2 "1.0.0"]])
+  (let [deps (aether/resolve-dependencies
+              :repositories test-repo
+              :coordinates '[{:group-id "demo" :artifact-id "demo2"
+                              :version "1.0.0"}])
         files (aether/dependency-files deps)]
     (is (= 2 (count files)))
-    (is (= 1 (count (filter #(file-path-eq % (io/file tmp-dir "local-repo" "demo" "demo" "1.0.0" "demo-1.0.0.jar"))
-                            files))))
-    (is (= 1 (count (filter #(file-path-eq % (io/file tmp-dir "local-repo" "demo" "demo2" "1.0.0" "demo2-1.0.0.jar"))
-                            files))))))
+    (is (= 1
+           (count
+            (filter
+             (file-path-matcher (local-repo-file "demo" "demo" "1.0.0"))
+             files))))
+    (is (= 1
+           (count
+            (filter
+             (file-path-matcher (local-repo-file "demo" "demo2" "1.0.0"))
+             files))))))
 
 (deftest resolve-deps-with-exclusions
-  (let [deps (aether/resolve-dependencies :repositories test-repo
-                                          :coordinates
-                                          '[[demo/demo2 "1.0.0" :exclusions [demo/demo]]])]
+  (let [deps (aether/resolve-dependencies
+              :repositories test-repo
+              :coordinates '[{:group-id "demo" :artifact-id "demo2"
+                              :version "1.0.0"
+                              :exclusions [{:group-id "demo"
+                                            :artifact-id "demo"}]}])]
     (is (= 1 (count deps)))
-    (is (= (.getAbsolutePath (io/file tmp-dir "local-repo" "demo" "demo2" "1.0.0" "demo2-1.0.0.jar"))
+    (is (= (.getAbsolutePath (local-repo-file "demo" "demo2" "1.0.0"))
            (.getAbsolutePath (first (aether/dependency-files deps)))))))
 
 (deftest deploy-jar
-  (aether/deploy :coordinates '[group/artifact "1.0.0"]
-                 :jar-file (io/file "test-repo" "demo" "demo" "1.0.0" "demo-1.0.0.jar")
-                 :pom-file (io/file "test-repo" "demo" "demo" "1.0.0" "demo-1.0.0.pom")
-                 :repository tmp-remote-repo)
-  (is (= 6 (count (.list (io/file tmp-remote-repo-dir "group" "artifact" "1.0.0"))))))
+  (aether/deploy
+   :coordinates '{:group-id "group" :artifact-id "artifact" :version "1.0.0"}
+   :jar-file (test-repo-file "demo" "demo" "1.0.0")
+   :pom-file (test-repo-file "demo" "demo" "1.0.0" "pom")
+   :repository tmp-remote-repo)
+  (is (= 6 (count (remote-repo-files "group" "artifact" "1.0.0")))))
 
 (deftest install-jar
-  (aether/install :coordinates '[group/artifact "1.0.0"]
-                  :jar-file (io/file "test-repo" "demo" "demo" "1.0.0" "demo-1.0.0.jar")
-                  :pom-file (io/file "test-repo" "demo" "demo" "1.0.0" "demo-1.0.0.pom"))
-  (is (= 3 (count (.list (io/file tmp-local-repo-dir "group" "artifact" "1.0.0"))))))
+  (aether/install
+   :coordinates '{:group-id "group" :artifact-id "artifact" :version "1.0.0"}
+   :jar-file (test-repo-file "demo" "demo" "1.0.0")
+   :pom-file (test-repo-file "demo" "demo" "1.0.0" "pom"))
+  (is (= 3 (count (local-repo-files "group" "artifact" "1.0.0")))))
 
 
 (comment
   "tests needed for:
-  
+
   repository authentication
   repository policies
   dependency options (scope/optional)

--- a/src/test/clojure/cemerick/pomegranate/lein_aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/lein_aether_test.clj
@@ -1,0 +1,100 @@
+(ns cemerick.pomegranate.lein-aether-test
+  (:require [cemerick.pomegranate.aether :as aether]
+            [cemerick.pomegranate.lein-aether :as lein-aether]
+            [clojure.java.io :as io])
+  (:use clojure.test
+        cemerick.pomegranate.test-utils))
+
+(use-fixtures :each clear-tmp bind-local-repo)
+
+(deftest dependency-roundtripping
+  (are [x] (= x (#'lein-aether/lein-spec
+                 (#'aether/dep-spec
+                  (#'aether/dependency
+                   (#'lein-aether/lein-dependency x)))))
+       '[ring "1.0.0" :optional true]
+       '[com.cemerick/pomegranate "0.0.1" :classifier "sources"]
+       '[demo/demo2 "1.0.0" :exclusions [[demo :classifier "jdk5"]]]))
+
+(deftest live-resolution
+  (let [deps '[[commons-logging "1.1"]]
+        graph '{[javax.servlet/servlet-api "2.3"] nil,
+                [avalon-framework "4.1.3"] nil,
+                [logkit "1.0.1"] nil,
+                [log4j "1.2.12"] nil,
+                [commons-logging "1.1"]
+                #{[javax.servlet/servlet-api "2.3"] [avalon-framework "4.1.3"]
+                  [logkit "1.0.1"] [log4j "1.2.12"]}}
+        hierarchy '{[commons-logging "1.1"]
+                    {[avalon-framework "4.1.3"] nil,
+                     [javax.servlet/servlet-api "2.3"] nil,
+                     [log4j "1.2.12"] nil,
+                     [logkit "1.0.1"] nil}}]
+    (is (= graph
+           (lein-aether/resolve-dependencies
+            :coordinates deps :retrieve false)))
+    (is (not (some jar-file? (local-repo-files))))
+
+    (doseq [[dep _] (lein-aether/resolve-dependencies :coordinates deps)]
+      (is (-> dep meta :file))
+      (is (-> dep meta :file .exists)))
+    (is (some jar-file? (local-repo-files)))
+
+    (is (= hierarchy (lein-aether/dependency-hierarchy deps graph)))))
+
+(deftest resolve-deps
+  (let [deps (lein-aether/resolve-dependencies
+              :repositories test-repo
+              :coordinates '[[demo/demo "1.0.0"]])]
+    (is (= 1 (count deps)))
+    (is (= (.getAbsolutePath (local-repo-file "demo" "demo" "1.0.0"))
+           (.getAbsolutePath (first (lein-aether/dependency-files deps)))))))
+
+(deftest resolve-deps-with-deps
+  (let [deps (lein-aether/resolve-dependencies
+              :repositories test-repo
+              :coordinates '[[demo/demo2 "1.0.0"]])
+        files (lein-aether/dependency-files deps)]
+    (is (= 2 (count files)))
+    (is (= 1
+           (count
+            (filter
+             (file-path-matcher (local-repo-file "demo" "demo" "1.0.0"))
+             files))))
+    (is (= 1
+           (count
+            (filter
+             (file-path-matcher (local-repo-file "demo" "demo2" "1.0.0"))
+             files))))))
+
+(deftest resolve-deps-with-exclusions
+  (let [deps (lein-aether/resolve-dependencies
+              :repositories test-repo
+              :coordinates '[[demo/demo2 "1.0.0" :exclusions [[demo/demo]]]])]
+    (is (= 1 (count deps)))
+    (is (= (.getAbsolutePath (local-repo-file "demo" "demo2" "1.0.0"))
+           (.getAbsolutePath (first (lein-aether/dependency-files deps)))))))
+
+(deftest deploy-jar
+  (lein-aether/deploy
+   :coordinates '[group/artifact "1.0.0"]
+   :jar-file (test-repo-file "demo" "demo" "1.0.0")
+   :pom-file (test-repo-file "demo" "demo" "1.0.0" "pom")
+   :repository tmp-remote-repo)
+  (is (= 6 (count (remote-repo-files "group" "artifact" "1.0.0")))))
+
+(deftest install-jar
+  (lein-aether/install
+   :coordinates '[group/artifact "1.0.0"]
+   :jar-file (test-repo-file "demo" "demo" "1.0.0")
+   :pom-file (test-repo-file "demo" "demo" "1.0.0" "pom"))
+  (is (= 3 (count (local-repo-files "group" "artifact" "1.0.0")))))
+
+
+(comment
+  "tests needed for:
+
+  repository authentication
+  repository policies
+  dependency options (scope/optional)
+  exclusion options (classifier/extension)")

--- a/src/test/clojure/cemerick/pomegranate/test_utils.clj
+++ b/src/test/clojure/cemerick/pomegranate/test_utils.clj
@@ -1,0 +1,71 @@
+(ns cemerick.pomegranate.test-utils
+  (:require [cemerick.pomegranate.aether :as aether]
+            [clojure.java.io :as io]))
+
+(def ^:private tmp-dir
+  (io/file (System/getProperty "java.io.tmpdir") "pomegranate-test-tmp"))
+(def ^:private tmp-remote-repo-dir
+  (.getAbsolutePath (io/file tmp-dir "remote-repo")))
+(def ^:private tmp-local-repo-dir
+  (io/file tmp-dir "local-repo"))
+
+(def test-repo
+  {"test-repo" "file://test-repo"})
+(def tmp-remote-repo
+  {"tmp-remote-repo" (str "file://" tmp-remote-repo-dir)})
+
+(defn- delete-recursive
+  [dir]
+  (when (.isDirectory dir)
+    (doseq [file (.listFiles dir)]
+      (delete-recursive file)))
+  (.delete dir))
+
+(defn clear-tmp
+  [f]
+  (delete-recursive (io/file tmp-dir))
+  (f))
+
+(defn bind-local-repo
+  [f]
+  (binding [aether/*local-repo* tmp-local-repo-dir]
+    (f)))
+
+(defn local-repo-files
+  ([]
+     (file-seq tmp-local-repo-dir))
+  ([group-id artifact-id version]
+     (.list (io/file tmp-local-repo-dir group-id artifact-id version))))
+
+(defn remote-repo-files
+  ([]
+     (file-seq tmp-local-repo-dir))
+  ([group-id artifact-id version]
+     (.list (io/file tmp-remote-repo-dir group-id artifact-id version))))
+
+(defn- repo-file
+  [repo group-id artifact-id version extension]
+  (io/file
+   repo group-id artifact-id version
+   (format "%s-%s.%s" artifact-id version extension)))
+
+(defn local-repo-file
+  ([group-id artifact-id version extension]
+     (repo-file tmp-local-repo-dir group-id artifact-id version extension))
+  ([group-id artifact-id version]
+     (local-repo-file group-id artifact-id version "jar")))
+
+(defn test-repo-file
+  ([group-id artifact-id version extension]
+     (repo-file "test-repo" group-id artifact-id version extension))
+  ([group-id artifact-id version]
+     (test-repo-file group-id artifact-id version "jar")))
+
+(defn jar-file?
+  [f]
+  (-> f .getName (.endsWith ".jar")))
+
+(defn file-path-matcher [file2]
+  (fn [file1]
+    (= (.getAbsolutePath file1)
+       (.getAbsolutePath file2))))


### PR DESCRIPTION
In order to generalise pomegranate, refactors c.p.aether to use maps
based on beans of the underlying aether objects. The maps have keys
that follow clojure naming standards.

The c.p.lein-aether namespace contains the same algorithm functions as the
c.p.aether namespace, but consumes and produces lein style dependency vectors.

The tests all pass, but I have not yet tested with lein. If the general approach seems reasonable, I can try it out with lein2.
