### PR TITLE
Stricter with update-in

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -433,7 +433,7 @@ kwarg to the repository kwarg.
     (reduce (fn [g ^DependencyNode n]
               (if-let [dep (.getDependency n)]
                 (update-in g [(dep-spec dep)]
-                           clojure.set/union
+                           (fnil clojure.set/union #{})
                            (->> (.getChildren n)
                              (map #(.getDependency %))
                              (map dep-spec)


### PR DESCRIPTION
Guard against (update-in {} [:a] union #{}) => {:a nil}.

Found this via a linter I'm building.
