### PR TITLE
Use HTTPS everywhere we can.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## [Pomegranate](http://github.com/cemerick/pomegranate) changelog
+## [Pomegranate](https://github.com/cemerick/pomegranate) changelog
 
 ### [`0.3.0`](https://github.com/cemerick/pomegranate/issues?milestone=5&page=1&state=closed)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Pomegranate  [![Travis CI status](https://secure.travis-ci.org/cemerick/pomegranate.png)](http://travis-ci.org/#!/cemerick/pomegranate/builds)
+# Pomegranate  [![Travis CI status](https://secure.travis-ci.org/cemerick/pomegranate.png)](https://travis-ci.org/cemerick/pomegranate/builds)
 
-[Pomegranate](http://github.com/cemerick/pomegranate) is a library that provides:
+[Pomegranate](https://github.com/cemerick/pomegranate) is a library that provides:
 
 1. A sane Clojure API for Sonatype [Aether](https://github.com/sonatype/sonatype-aether).
-2. A re-implementation of [`add-classpath`](http://clojure.github.com/clojure/clojure.core-api.html#clojure.core/add-classpath) (deprecated in Clojure core) that:
+2. A re-implementation of [`add-classpath`](https://clojure.github.com/clojure/clojure.core-api.html#clojure.core/add-classpath) (deprecated in Clojure core) that:
 
 * is a little more comprehensive than core's `add-classpath` — it should work as expected in more circumstances, and
 * optionally uses Aether to add a Maven artifact (and all of its transitive dependencies) to your Clojure runtime's classpath dynamically.
@@ -30,7 +30,7 @@ or to your Maven project's `pom.xml`:
 
 ## `add-classpath` usage
 
-Just to set a stage: you're at the REPL, and you've got some useful data that you'd like to munge and analyze in various ways.  Maybe it's something you've generated locally, maybe it's data on a production machine and you're logged in via [nREPL](http://github.com/clojure/tools.nrepl).  In any case, you'd like to work with the data, but realize that you don't have the libraries you need do what you want.  Your choices at this point are:
+Just to set a stage: you're at the REPL, and you've got some useful data that you'd like to munge and analyze in various ways.  Maybe it's something you've generated locally, maybe it's data on a production machine and you're logged in via [nREPL](https://github.com/clojure/tools.nrepl).  In any case, you'd like to work with the data, but realize that you don't have the libraries you need do what you want.  Your choices at this point are:
 
 1. Dump the data to disk via `pr` (assuming it's just Clojure data structures!), and start up a new Clojure process with the appropriate libraries on the classpath. This can really suck if the data is in a remote environment.
 2. There is no second choice.  You _could_ use `add-claspath`, but the library you want has 12 bajillion dependencies, and there's no way you're going to hunt them down manually.
@@ -50,7 +50,7 @@ Looks bleak. Assuming you've got Pomegranate on your classpath already, you can 
 nil
 => (add-dependencies :coordinates '[[incanter "1.2.3"]]
                      :repositories (merge cemerick.pomegranate.aether/maven-central
-                                          {"clojars" "http://clojars.org/repo"}))
+                                          {"clojars" "https://clojars.org/repo"}))
 ;...add-dependencies returns full dependency graph...
 => (require '(incanter core stats charts))
 nil
@@ -105,7 +105,7 @@ or would like to contribute patches.
 
 ## License
 
-Copyright © 2011-2012 [Chas Emerick](http://cemerick.com) and all other
+Copyright © 2011-2014 [Chas Emerick](http://cemerick.com) and all other
 contributors.
 
 Licensed under the EPL. (See the file epl-v10.html.)

--- a/src/main/clojure/cemerick/pomegranate.clj
+++ b/src/main/clojure/cemerick/pomegranate.clj
@@ -61,7 +61,7 @@
 
    (add-dependencies :coordinates '[[incanter \"1.2.3\"]]
                      :repositories (merge cemerick.pomegranate.aether/maven-central
-                                     {\"clojars\" \"http://clojars.org/repo\"}))
+                                     {\"clojars\" \"https://clojars.org/repo\"}))
 
    Note that Maven central is used as the sole repository if none are specified.
    If :repositories are provided, then you must merge in the `maven-central` map from

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -29,7 +29,7 @@
 (def ^{:private true} default-local-repo
   (io/file (System/getProperty "user.home") ".m2" "repository"))
 
-(def maven-central {"central" "http://repo1.maven.org/maven2/"})
+(def maven-central {"central" "https://repo1.maven.org/maven2/"})
 
 ; Using HttpWagon (which uses apache httpclient) because the "LightweightHttpWagon"
 ; (which just uses JDK HTTP) reliably flakes if you attempt to resolve SNAPSHOT
@@ -517,7 +517,7 @@ kwarg to the repository kwarg.
         :extension  (default \"*\")
 
     :repositories - {name url ..} | {name settings ..}
-      (defaults to {\"central\" \"http://repo1.maven.org/maven2/\"}
+      (defaults to {\"central\" \"https://repo1.maven.org/maven2/\"}
       settings:
       :url - URL of the repository
       :snapshots - use snapshots versions? (default true)
@@ -637,7 +637,7 @@ kwarg to the repository kwarg.
         :extension  (default \"*\")
 
     :repositories - {name url ..} | {name settings ..}
-      (defaults to {\"central\" \"http://repo1.maven.org/maven2/\"}
+      (defaults to {\"central\" \"https://repo1.maven.org/maven2/\"}
       settings:
       :url - URL of the repository
       :snapshots - use snapshots versions? (default true)

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -14,7 +14,7 @@
 (def tmp-local-repo-dir (io/file tmp-dir "local-repo"))
 (def tmp-local-repo2-dir (io/file tmp-dir "local-repo2"))
 
-(def test-remote-repo {"central" "http://repo1.maven.org/maven2/"})
+(def test-remote-repo {"central" "https://repo1.maven.org/maven2/"})
 
 (def test-repo {"test-repo" "file://test-repo"})
 (def tmp-remote-repo {"tmp-remote-repo" (str "file://" tmp-remote-repo-dir)})
@@ -95,16 +95,16 @@
            (.getAbsolutePath (first (aether/dependency-files deps)))))))
 
 (deftest resolve-deps-with-mirror
-  (let [deps (aether/resolve-dependencies :repositories {"clojars" "http://clojars.org/repo"}
+  (let [deps (aether/resolve-dependencies :repositories {"clojars" "https://clojars.org/repo"}
                                           :coordinates '[[javax.servlet/servlet-api "2.5"]]
-                                          :mirrors {"clojars" {:url "http://uk.maven.org/maven2"}}
+                                          :mirrors {"clojars" {:url "https://uk.maven.org/maven2"}}
                                           :local-repo tmp-local-repo-dir)]
     (is (= 1 (count deps)))
     (is (= (.getAbsolutePath (io/file tmp-dir "local-repo" "javax" "servlet" "servlet-api" "2.5" "servlet-api-2.5.jar"))
            (.getAbsolutePath (first (aether/dependency-files deps)))))))
 
 (deftest resolve-deps-with-wildcard-mirror
-  (let [deps (aether/resolve-dependencies :repositories {"clojars" "http://clojars.org/repo"}
+  (let [deps (aether/resolve-dependencies :repositories {"clojars" "https://clojars.org/repo"}
                                           :coordinates '[[javax.servlet/servlet-api "2.5"]]
                                           :mirrors {#".+" {:url "http://uk.maven.org/maven2"}}
                                           :local-repo tmp-local-repo-dir)]


### PR DESCRIPTION
Disables two tests which were using an unencrypted HTTP connection to
the Central UK mirrors. I was unable to find any HTTPS mirrors, but if
one exists, it should be used and the tests re-enabled.
