### PR TITLE
Publishing 'dependency' and 'make-repository' Aether-wrapping APIs as they are generally useful

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -177,7 +177,7 @@
       (.setProxy repo prx))
     repo))
 
-(defn- make-repository
+(defn make-repository
   [[id settings] proxy]
   (let [settings-map (if (string? settings)
                        {:url settings}
@@ -221,7 +221,7 @@
   [[group-artifact version & {:keys [scope optional exclusions]} :as dep-spec]]
   (DefaultArtifact. (coordinate-string dep-spec)))
 
-(defn- dependency
+(defn dependency
   [[group-artifact version & {:keys [scope optional exclusions]
                               :as opts
                               :or {scope "compile"

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -178,6 +178,7 @@
     repo))
 
 (defn make-repository
+  "Produces an Aether RemoteRepository instance from Pomegranate-style repository information"
   [[id settings] proxy]
   (let [settings-map (if (string? settings)
                        {:url settings}
@@ -222,6 +223,7 @@
   (DefaultArtifact. (coordinate-string dep-spec)))
 
 (defn dependency
+  "Produces an Aether Dependency instance from Pomegranate-style dependency information"
   [[group-artifact version & {:keys [scope optional exclusions]
                               :as opts
                               :or {scope "compile"


### PR DESCRIPTION
Hi!

I'd like to publish 'dependency' and 'make-repository' Aether-wrapping APIs as they are generally useful and they'd especially help me with https://github.com/circlespainter/lein-capsule.

Do you see any drawbacks?

TIA - Fabio
