### PR TITLE
Use eclipse aether instead of sonatype aether.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Pomegranate](http://github.com/cemerick/pomegranate) is a library that provides:
 
-1. A sane Clojure API for Sonatype [Aether](https://github.com/sonatype/sonatype-aether).
+1. A sane Clojure API for Eclipse [Aether](http://www.eclipse.org/aether/).
 2. A re-implementation of [`add-classpath`](http://clojure.github.com/clojure/clojure.core-api.html#clojure.core/add-classpath) (deprecated in Clojure core) that:
 
 * is a little more comprehensive than core's `add-classpath` — it should work as expected in more circumstances, and

--- a/pom.xml
+++ b/pom.xml
@@ -31,35 +31,40 @@
     <properties>
         <clojure.version>1.3.0</clojure.version>
 
-        <aetherVersion>1.13.1</aetherVersion>
-        <mavenVersion>3.0.4</mavenVersion>
+        <aetherVersion>1.0.2.v20150114</aetherVersion>
+        <mavenVersion>3.3.3</mavenVersion>
         <wagonVersion>2.2</wagonVersion>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-api</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-connector-basic</artifactId>
+            <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-util</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-impl</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
-            <artifactId>aether-connector-file</artifactId>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-transport-file</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
-            <artifactId>aether-connector-wagon</artifactId>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-transport-wagon</artifactId>
             <version>${aetherVersion}</version>
             <exclusions>
               <exclusion>

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -18,6 +18,8 @@
 
 (def test-repo {"test-repo" "file://test-repo"})
 (def tmp-remote-repo {"tmp-remote-repo" (str "file://" tmp-remote-repo-dir)})
+;; aether no longer creates checksums when uploading signatures
+(def tmp-asc-remote-repo {"tmp-remote-repo" {:url (str "file://" tmp-remote-repo-dir) :checksum :ignore}})
 
 (defn delete-recursive
   [dir]
@@ -80,9 +82,9 @@
 
 (deftest impl-detail-types
   (let [args [:coordinates '[[commons-logging "1.1"]] :local-repo tmp-local-repo-dir]]
-    (is (instance? org.sonatype.aether.resolution.DependencyResult
+    (is (instance? org.eclipse.aether.resolution.DependencyResult
           (apply aether/resolve-dependencies* args)))
-    (is (instance? org.sonatype.aether.collection.CollectResult
+    (is (instance? org.eclipse.aether.collection.CollectResult
           (apply aether/resolve-dependencies* :retrieve false args)))))
 
 (deftest resolve-deps-with-proxy
@@ -217,14 +219,10 @@
   (is (= #{"demo-1.0.0.pom.md5"
            "demo-1.0.0.pom.sha1"
            "demo-1.0.0.pom"
-           "demo-1.0.0.pom.asc.md5"
-           "demo-1.0.0.pom.asc.sha1"
            "demo-1.0.0.pom.asc"
            "demo-1.0.0.jar.md5"
            "demo-1.0.0.jar.sha1"
            "demo-1.0.0.jar"
-           "demo-1.0.0.jar.asc.md5"
-           "demo-1.0.0.jar.asc.sha1"
            "demo-1.0.0.jar.asc"}
          (set (.list (io/file tmp-remote-repo-dir "demo" "demo" "1.0.0")))))
   (is (= '{[demo "1.0.0"] nil}
@@ -238,12 +236,12 @@
                                       '[[demo "1.0.0" :extension "pom"]]
                                       :local-repo tmp-local-repo2-dir)))
   (is (= '{[demo "1.0.0" :extension "jar.asc"] nil}
-         (aether/resolve-dependencies :repositories tmp-remote-repo
+         (aether/resolve-dependencies :repositories tmp-asc-remote-repo
                                       :coordinates
                                       '[[demo "1.0.0" :extension "jar.asc"]]
                                       :local-repo tmp-local-repo2-dir)))
   (is (= '{[demo "1.0.0" :extension "pom.asc"] nil}
-         (aether/resolve-dependencies :repositories tmp-remote-repo
+         (aether/resolve-dependencies :repositories tmp-asc-remote-repo
                                       :coordinates
                                       '[[demo "1.0.0" :extension "pom.asc"]]
                                       :local-repo tmp-local-repo2-dir))))
@@ -264,7 +262,7 @@
            "demo-1.0.0.pom"
            "demo-1.0.0.jar.asc"
            "demo-1.0.0.pom.asc"
-           "_maven.repositories"}
+           "_remote.repositories"}
          (set (.list (io/file tmp-local-repo-dir "demo" "demo" "1.0.0"))))))
 
 (deftest deploy-exceptions


### PR DESCRIPTION
Sonatype aether is deprecated, and new Maven now uses eclipse aether.
This enables us to track the new features and fixes as well as improving
interop with maven-based tools.