### PR TITLE
Make `merge-versions-from-managed-coords` fn public

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -652,7 +652,7 @@ kwarg to the repository kwarg.
     (add-version-from-managed-coord coord (find-managed-coord coord managed-coords))
     coord))
 
-(defn- merge-versions-from-managed-coords
+(defn merge-versions-from-managed-coords
   "Given a vector of coordinates (e.g. [[group/name <\"version\"> & settings] ..])
   where the version field is optional or can be nil, and a vector of managed coordinates,
   returns an updated vector of coordinates with version numbers merged in from the


### PR DESCRIPTION
Prior to this commit, the `merge-versions-from-managed-coords` fn
was marked as private, because I didn't think it would need to be
called from outside of pomegranate.

However, it turned out to be a requirement to be able to call this
from leiningen in order to implement support for managed dependencies
in leiningen, and the function seems like it could be generally
useful for other cases, so this commit makes it public.

In the current leiningen code we are simply calling the private
function, so getting this merged and release is not a blocker for
anything, but it'd permit a desirable minor cleanup in the
corresponding leiningen code.
