### PR TITLE
Update to dynapath 0.2.4 to support Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>org.tcrawley</groupId>
           <artifactId>dynapath</artifactId>
-          <version>0.2.3</version>
+          <version>0.2.4</version>
         </dependency>
 
         <!-- wagons for dependency resolution -->


### PR DESCRIPTION
Java 9 no longer has sun.misc.Launcher, which dynapath < 0.2.4 assumed
was always available.

This enables pomegranate to work under early access builds of Java 9.