### PR TITLE
Update to dynapath 0.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
           <groupId>org.tcrawley</groupId>
           <artifactId>dynapath</artifactId>
-          <version>0.2.4</version>
+          <version>0.2.5</version>
         </dependency>
 
         <!-- wagons for dependency resolution -->


### PR DESCRIPTION
This version addresses two Java 9 related issues:

* 0.2.4 would fail under Java 9 if AOT'd
* the latest Java 9 build (9-ea+148) broke dynapath's reflection to make
  URLClassLoader modifiable