### PR TITLE
Upgrade aether

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
     <properties>
         <clojure.version>1.3.0</clojure.version>
 
-        <aetherVersion>0.9.0.M2</aetherVersion>
-        <mavenVersion>3.1.0</mavenVersion>
-        <wagonVersion>2.2</wagonVersion>
+        <aetherVersion>1.1.0</aetherVersion>
+        <mavenVersion>3.3.9</mavenVersion>
+        <wagonVersion>2.12</wagonVersion>
     </properties>
 
     <dependencies>
@@ -59,22 +59,21 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-file</artifactId>
+            <artifactId>aether-transport-file</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-wagon</artifactId>
+            <artifactId>aether-transport-http</artifactId>
             <version>${aetherVersion}</version>
-            <exclusions>
-              <exclusion>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-              </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.tesla.maven</groupId>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-connector-basic</artifactId>
+            <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-aether-provider</artifactId>
             <version>${mavenVersion}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,34 +31,39 @@
     <properties>
         <clojure.version>1.3.0</clojure.version>
 
-        <aetherVersion>1.13.1</aetherVersion>
-        <mavenVersion>3.0.4</mavenVersion>
+        <aetherVersion>0.9.0.M2</aetherVersion>
+        <mavenVersion>3.1.0</mavenVersion>
         <wagonVersion>2.2</wagonVersion>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-api</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-spi</artifactId>
+            <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-util</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-impl</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-connector-file</artifactId>
             <version>${aetherVersion}</version>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
+            <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-connector-wagon</artifactId>
             <version>${aetherVersion}</version>
             <exclusions>
@@ -69,7 +74,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
+            <groupId>io.tesla.maven</groupId>
             <artifactId>maven-aether-provider</artifactId>
             <version>${mavenVersion}</version>
         </dependency>
@@ -78,7 +83,6 @@
           <artifactId>dynapath</artifactId>
           <version>0.2.5</version>
         </dependency>
-
         <!-- wagons for dependency resolution -->
         <dependency>
           <groupId>org.apache.maven.wagon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <version>${wagonVersion}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.22</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cemerick</groupId>
     <artifactId>pomegranate</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <name>pomegranate</name>
     <description />
     <url>http://github.com/cemerick/pomegranate</url>

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -287,7 +287,7 @@
       :passphrase - passphrase to log in wth
       :private-key-file - private key file to log in with
       :update - :daily (default) | :always | :never
-      :checksum - :fail | :ignore | :warn (default)
+      :checksum - :fail (default) | :ignore | :warn
   :local-repo - path to the local repository (defaults to ~/.m2/repository)
   :transfer-listener - same as provided to resolve-dependencies
 

--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -4,37 +4,39 @@
             clojure.set
             [clojure.string :as str]
             clojure.stacktrace)
-  (:import (org.apache.maven.repository.internal DefaultServiceLocator MavenRepositorySystemSession)
-           (org.sonatype.aether.transfer TransferListener)
-           (org.sonatype.aether.connector.file FileRepositoryConnectorFactory)
-           (org.sonatype.aether.connector.wagon WagonProvider WagonRepositoryConnectorFactory)
-           (org.sonatype.aether.spi.connector RepositoryConnectorFactory)
-           (org.sonatype.aether.repository Proxy  Authentication
-                                           RepositoryPolicy LocalRepository RemoteRepository
-                                           MirrorSelector)
-           (org.sonatype.aether.util.repository DefaultProxySelector)
-           (org.sonatype.aether.graph Dependency Exclusion DependencyNode)
-           (org.sonatype.aether.collection CollectRequest)
-           (org.sonatype.aether.resolution DependencyRequest ArtifactRequest
-                                           ArtifactResult VersionRequest)
-           (org.sonatype.aether.util.artifact DefaultArtifact ArtifactProperties)
-           (org.sonatype.aether.deployment DeployRequest)
-           (org.sonatype.aether.installation InstallRequest)
-           (org.sonatype.aether.util.version GenericVersionScheme)))
+  (:import (org.eclipse.aether RepositorySystem)
+           (org.eclipse.aether.transfer TransferListener)
+           (org.eclipse.aether.artifact Artifact)
+           (org.eclipse.aether.connector.file FileRepositoryConnectorFactory)
+           (org.eclipse.aether.connector.wagon WagonProvider WagonRepositoryConnectorFactory)
+           (org.eclipse.aether.spi.connector RepositoryConnectorFactory)
+           (org.eclipse.aether.repository Proxy  Authentication
+                                          RepositoryPolicy LocalRepository RemoteRepository RemoteRepository$Builder
+                                          MirrorSelector)
+           (org.eclipse.aether.util.repository DefaultProxySelector AuthenticationBuilder)
+           (org.eclipse.aether.graph Dependency Exclusion DependencyNode)
+           (org.eclipse.aether.collection CollectRequest)
+           (org.eclipse.aether.resolution DependencyRequest ArtifactRequest
+                                          ArtifactResult VersionRequest)
+           (org.eclipse.aether.artifact DefaultArtifact ArtifactProperties)
+           (org.eclipse.aether.util.artifact SubArtifact)
+           (org.eclipse.aether.deployment DeployRequest)
+           (org.eclipse.aether.installation InstallRequest)
+           (org.eclipse.aether.util.version GenericVersionScheme)))
 
 (def ^{:private true} default-local-repo
   (io/file (System/getProperty "user.home") ".m2" "repository"))
 
 (def maven-central {"central" "http://repo1.maven.org/maven2/"})
 
-; Using HttpWagon (which uses apache httpclient) because the "LightweightHttpWagon"
-; (which just uses JDK HTTP) reliably flakes if you attempt to resolve SNAPSHOT
-; artifacts from an HTTPS password-protected repository (like a nexus instance)
-; when other un-authenticated repositories are included in the resolution.
-; My theory is that the JDK HTTP impl is screwing up connection pooling or something,
-; and reusing the same connection handle for the HTTPS repo as it used for e.g.
-; central, without updating the authentication info.
-; In any case, HttpWagon is what Maven 3 uses, and it works.
+;; Using HttpWagon (which uses apache httpclient) because the "LightweightHttpWagon"
+;; (which just uses JDK HTTP) reliably flakes if you attempt to resolve SNAPSHOT
+;; artifacts from an HTTPS password-protected repository (like a nexus instance)
+;; when other un-authenticated repositories are included in the resolution.
+;; My theory is that the JDK HTTP impl is screwing up connection pooling or something,
+;; and reusing the same connection handle for the HTTPS repo as it used for e.g.
+;; central, without updating the authentication info.
+;; In any case, HttpWagon is what Maven 3 uses, and it works.
 (def ^{:private true} wagon-factories (atom {"http" #(org.apache.maven.wagon.providers.http.HttpWagon.)
                                              "https" #(org.apache.maven.wagon.providers.http.HttpWagon.)}))
 
@@ -51,12 +53,12 @@
   WagonProvider
   (release [_ wagon])
   (lookup [_ role-hint]
-    (when-let [f (get @wagon-factories role-hint)]
-      (try 
-        (f)
-        (catch Exception e
-          (clojure.stacktrace/print-cause-trace e)
-          (throw e))))))
+          (when-let [f (get @wagon-factories role-hint)]
+            (try
+              (f)
+              (catch Exception e
+                (clojure.stacktrace/print-cause-trace e)
+                (throw e))))))
 
 (deftype TransferListenerProxy [listener-fn]
   TransferListener
@@ -68,10 +70,10 @@
   (transferSucceeded [_ e] (listener-fn e)))
 
 (defn- transfer-event
-  [^org.sonatype.aether.transfer.TransferEvent e]
-  ; INITIATED, STARTED, PROGRESSED, CORRUPTED, SUCCEEDED, FAILED
+  [^org.eclipse.aether.transfer.TransferEvent e]
+  ;; INITIATED, STARTED, PROGRESSED, CORRUPTED, SUCCEEDED, FAILED
   {:type (-> e .getType .name str/lower-case keyword)
-   ; :get :put
+   ;; :get :put
    :method (-> e .getRequestType str/lower-case keyword)
    :transferred (.getTransferredBytes e)
    :error (.getException e)
@@ -103,11 +105,12 @@
 
 (defn- repository-system
   []
-  (.getService (doto (DefaultServiceLocator.)
-                 (.addService RepositoryConnectorFactory FileRepositoryConnectorFactory)
-                 (.addService RepositoryConnectorFactory WagonRepositoryConnectorFactory)
-                 (.addService WagonProvider PomegranateWagonProvider))
-               org.sonatype.aether.RepositorySystem))
+  (.getService
+   (doto (org.apache.maven.repository.internal.MavenRepositorySystemUtils/newServiceLocator)
+     (.setService WagonProvider PomegranateWagonProvider)
+     (.addService RepositoryConnectorFactory FileRepositoryConnectorFactory)
+     (.addService RepositoryConnectorFactory WagonRepositoryConnectorFactory))
+   RepositorySystem))
 
 (defn- construct-transfer-listener
   [transfer-listener]
@@ -124,14 +127,16 @@
 
 (defn repository-session
   [{:keys [repository-system local-repo offline? transfer-listener mirror-selector]}]
-  (-> (MavenRepositorySystemSession.)
-    (.setLocalRepositoryManager (.newLocalRepositoryManager repository-system
-                                  (-> (io/file (or local-repo default-local-repo))
-                                    .getAbsolutePath
-                                    LocalRepository.)))
-    (.setMirrorSelector mirror-selector)
-    (.setOffline (boolean offline?))
-    (.setTransferListener (construct-transfer-listener transfer-listener))))
+  (let [session (org.apache.maven.repository.internal.MavenRepositorySystemUtils/newSession)]
+    (doto session
+      (.setLocalRepositoryManager (.newLocalRepositoryManager
+                                   repository-system
+                                   session
+                                   (LocalRepository.
+                                    (io/file (or local-repo default-local-repo)))))
+      (.setMirrorSelector mirror-selector)
+      (.setOffline (boolean offline?))
+      (.setTransferListener (construct-transfer-listener transfer-listener)))))
 
 (def update-policies {:daily RepositoryPolicy/UPDATE_POLICY_DAILY
                       :always RepositoryPolicy/UPDATE_POLICY_ALWAYS
@@ -144,46 +149,54 @@
 (defn- policy
   [policy-settings enabled?]
   (RepositoryPolicy.
-    (boolean enabled?)
-    (update-policies (:update policy-settings :daily))
-    (checksum-policies (:checksum policy-settings :fail))))
+   (boolean enabled?)
+   (update-policies (:update policy-settings :daily))
+   (checksum-policies (:checksum policy-settings :fail))))
 
 (defn- set-policies
   [repo settings]
   (doto repo
-    (.setPolicy true (policy settings (:snapshots settings true)))
-    (.setPolicy false (policy settings (:releases settings true)))))
+    (.setSnapshotPolicy (policy settings (:snapshots settings true)))
+    (.setReleasePolicy (policy settings (:releases settings true)))))
 
 (defn- set-authentication
   "Calls the setAuthentication method on obj"
   [obj {:keys [username password passphrase private-key-file] :as settings}]
   (if (or username password private-key-file passphrase)
-    (.setAuthentication obj (Authentication. username password private-key-file passphrase))
+    (doto obj
+      (.setAuthentication
+       (.build
+        (doto (AuthenticationBuilder.)
+          (.addUsername username)
+          (.addPassword password)
+          (.addPrivateKey private-key-file passphrase)))))
     obj))
 
-(defn- set-proxy 
-  [repo {:keys [type host port non-proxy-hosts ] 
-         :or {type "http"} 
-         :as proxy} ]
-  (if (and repo host port)
+(defn- set-proxy
+  [repo-builder {:keys [type host port non-proxy-hosts ]
+                 :or {type "http"}
+                 :as proxy} ]
+  (if (and repo-builder host port)
     (let [prx-sel (doto (DefaultProxySelector.)
                     (.add (set-authentication (Proxy. type host port nil) proxy)
                           non-proxy-hosts))
-          prx (.getProxy prx-sel repo)]
-      (.setProxy repo prx))
-    repo))
+          prx (.getProxy prx-sel (.build repo-builder))] ; ugg.
+      ;; Don't know how to get around "building" the repo for this
+      (.setProxy repo-builder prx))
+    repo-builder))
 
 (defn- make-repository
   [[id settings] proxy]
   (let [settings-map (if (string? settings)
                        {:url settings}
-                       settings)] 
-    (doto (RemoteRepository. id
-                             (:type settings-map "default")
-                             (str (:url settings-map)))
-      (set-policies settings-map)
-      (set-proxy proxy)
-      (set-authentication settings-map))))
+                       settings)]
+    (.build
+     (doto (RemoteRepository$Builder. id
+                                      (:type settings-map "default")
+                                      (str (:url settings-map)))
+       (set-policies settings-map)
+       (set-authentication settings-map)
+       (set-proxy proxy)))))
 
 (defn- group
   [group-artifact]
@@ -196,17 +209,17 @@
    given a lein-style dependency spec.  :extension defaults to jar."
   [[group-artifact version & {:keys [classifier extension] :or {extension "jar"}}]]
   (->> [(group group-artifact) (name group-artifact) extension classifier version]
-    (remove nil?)
-    (interpose \:)
-    (apply str)))
+       (remove nil?)
+       (interpose \:)
+       (apply str)))
 
 (defn- exclusion
   [[group-artifact & {:as opts}]]
   (Exclusion.
-    (group group-artifact)
-    (name group-artifact)
-    (:classifier opts "*")
-    (:extension opts "*")))
+   (group group-artifact)
+   (name group-artifact)
+   (:classifier opts "*")
+   (:extension opts "*")))
 
 (defn- normalize-exclusion-spec [spec]
   (if (symbol? spec)
@@ -242,8 +255,8 @@
   [^Dependency dep]
   (let [artifact (.getArtifact dep)]
     (-> (merge (bean dep) (bean artifact))
-      dep-spec*
-      (with-meta {:dependency dep :file (.getFile artifact)}))))
+        dep-spec*
+        (with-meta {:dependency dep :file (.getFile artifact)}))))
 
 (defn- dep-spec*
   "Base function for producing lein-style dependency spec vectors for dependencies
@@ -479,13 +492,16 @@ kwarg to the repository kwarg.
                        :url (.getUrl repo)
                        :snapshots (-> repo (.getPolicy true) .isEnabled)
                        :releases (-> repo (.getPolicy false) .isEnabled)}
-            
+
             {:keys [name repo-manager content-type] :as mirror-spec}
             (mirror-selector-fn repo-spec)]
         (when-let [mirror (and mirror-spec (make-repository [name mirror-spec] proxy))]
-        (-> (.setMirroredRepositories mirror [repo])
-          (.setRepositoryManager (boolean repo-manager))
-          (.setContentType (or content-type "default"))))))))
+          (-> (RemoteRepository$Builder. mirror)
+              (.setMirroredRepositories [repo])
+              (.setRepositoryManager (boolean repo-manager))
+              (.setContentType (or content-type "default"))
+              (.build)))))))
+
 
 (defn resolve-artifacts*
   "Resolves artifacts for the coordinates kwarg, using repositories from the
@@ -494,8 +510,8 @@ kwarg to the repository kwarg.
    Retrieval of dependencies can be disabled by providing `:retrieve false` as a
    kwarg.
 
-   Returns an sequence of either `org.sonatype.aether.VersionResult`
-   if `:retrieve false`, or `org.sonatype.aether.ArtifactResult` if
+   Returns an sequence of either `org.eclipse.aether.VersionResult`
+   if `:retrieve false`, or `org.eclipse.aether.ArtifactResult` if
    `:retrieve true` (the default).
 
    If you don't want to mess with the Aether implementation classes, then use
@@ -536,7 +552,7 @@ kwarg to the repository kwarg.
             interactive console program
         - a function of one argument, which will be called with a map derived from
             each event.
-        - an instance of org.sonatype.aether.transfer.TransferListener
+        - an instance of org.eclipse.aether.transfer.TransferListener
 
     :proxy - proxy configuration, can be nil, the host scheme and type must match
       :host - proxy hostname
@@ -678,8 +694,8 @@ kwarg to the repository kwarg.
   "Collects dependencies for the coordinates kwarg, using repositories from the
    `:repositories` kwarg.
    Retrieval of dependencies can be disabled by providing `:retrieve false` as a kwarg.
-   Returns an instance of either `org.sonatype.aether.collection.CollectResult` if
-   `:retrieve false` or `org.sonatype.aether.resolution.DependencyResult` if
+   Returns an instance of either `org.eclipse.aether.collection.CollectResult` if
+   `:retrieve false` or `org.eclipse.aether.resolution.DependencyResult` if
    `:retrieve true` (the default).  If you don't want to mess with the Aether
    implementation classes, then use `resolve-dependencies` instead.
 
@@ -722,9 +738,9 @@ kwarg to the repository kwarg.
             interactive console program
         - a function of one argument, which will be called with a map derived from
             each event.
-        - an instance of org.sonatype.aether.transfer.TransferListener
+        - an instance of org.eclipse.aether.transfer.TransferListener
 
-    :proxy - proxy configuration, can be nil, the host scheme and type must match 
+    :proxy - proxy configuration, can be nil, the host scheme and type must match
       :host - proxy hostname
       :type - http  (default) | http | https
       :port - proxy port
@@ -764,13 +780,13 @@ kwarg to the repository kwarg.
         deps (coords->Dependencies files coordinates)
         managed-deps (coords->Dependencies files managed-coordinates)
         collect-request (doto (CollectRequest. deps
-                                managed-deps
-                                (vec (map #(let [repo (make-repository % proxy)]
-                                             (-> session
-                                               (.getMirrorSelector)
-                                               (.getMirror repo)
-                                               (or repo)))
-                                       repositories)))
+                                               managed-deps
+                                               (vec (map #(let [repo (make-repository % proxy)]
+                                                            (-> session
+                                                                (.getMirrorSelector)
+                                                                (.getMirror repo)
+                                                                (or repo)))
+                                                         repositories)))
                           (.setRequestContext "runtime"))]
     (if retrieve
       (.resolveDependencies system session (DependencyRequest. collect-request nil))
@@ -848,4 +864,3 @@ kwarg to the repository kwarg.
                     [root (dependency-hierarchy (dep-graph root) dep-graph)])]
     (when (seq hierarchy)
       (into (sorted-map-by #(apply compare (map coordinate-string %&))) hierarchy))))
-

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -330,6 +330,8 @@
      :local-repo tmp-local-repo-dir))
   (is (= 3 (count (.list (io/file tmp-local-repo-dir "group" "artifact" "1.0.0"))))))
 
+(java.lang.System/setProperty "aether.checksums.forSignature" "true")
+
 (deftest deploy-artifacts
   (aether/deploy-artifacts
    :artifacts '[[demo "1.0.0"]
@@ -355,7 +357,7 @@
            "demo-1.0.0.jar.asc.md5"
            "demo-1.0.0.jar.asc.sha1"
            "demo-1.0.0.jar.asc"}
-         (set (.list (io/file tmp-remote-repo-dir "demo" "demo" "1.0.0")))))
+         (set (.list (io/file tmp-remote-repo-dir "demo" "demo" "1.0.0")))) "Should deploy correctly demo \"1.0.0\"")
   (is (= '{[demo "1.0.0"] nil}
          (aether/resolve-dependencies :repositories tmp-remote-repo
                                       :coordinates
@@ -379,10 +381,10 @@
 
 (deftest install-artifacts
   (aether/install-artifacts
-    :artifacts '[[demo "1.0.0"]
-                 [demo "1.0.0" :extension "jar.asc"]
-                 [demo "1.0.0" :extension "pom"]
-                 [demo "1.0.0" :extension "pom.asc"]]
+   :artifacts '[[demo "1.0.0"]
+                [demo "1.0.0" :extension "jar.asc"]
+                [demo "1.0.0" :extension "pom"]
+                [demo "1.0.0" :extension "pom.asc"]]
    ;; note: the .asc files in the test-repo are dummies, but it doesn't matter for this test
    :files {'[demo "1.0.0"] (io/file "test-repo" "demo" "demo" "1.0.0" "demo-1.0.0.jar")
            '[demo "1.0.0" :extension "jar.asc"] (io/file "test-repo" "demo" "demo" "1.0.0" "demo-1.0.0.jar.asc")

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -80,9 +80,9 @@
 
 (deftest impl-detail-types
   (let [args [:coordinates '[[commons-logging "1.1"]] :local-repo tmp-local-repo-dir]]
-    (is (instance? org.sonatype.aether.resolution.DependencyResult
+    (is (instance? org.eclipse.aether.resolution.DependencyResult
           (apply aether/resolve-dependencies* args)))
-    (is (instance? org.sonatype.aether.collection.CollectResult
+    (is (instance? org.eclipse.aether.collection.CollectResult
           (apply aether/resolve-dependencies* :retrieve false args)))))
 
 (deftest resolve-deps-with-proxy
@@ -393,7 +393,7 @@
            "demo-1.0.0.pom"
            "demo-1.0.0.jar.asc"
            "demo-1.0.0.pom.asc"
-           "_maven.repositories"}
+           "_remote.repositories"}
          (set (.list (io/file tmp-local-repo-dir "demo" "demo" "1.0.0"))))))
 
 (deftest deploy-exceptions

--- a/test-repo/demo/demo/1.0.0/demo-1.0.0.jar.asc.md5
+++ b/test-repo/demo/demo/1.0.0/demo-1.0.0.jar.asc.md5
@@ -1,0 +1,1 @@
+b5f91153fbd3dc8bc29e98c73d46655f  demo-1.0.0.jar.asc

--- a/test-repo/demo/demo/1.0.0/demo-1.0.0.jar.asc.sha1
+++ b/test-repo/demo/demo/1.0.0/demo-1.0.0.jar.asc.sha1
@@ -1,0 +1,1 @@
+d94055dca4e0f2bcc455e278287dcf0e7c4034e1  demo-1.0.0.jar.asc

--- a/test-repo/demo/demo/1.0.0/demo-1.0.0.pom.asc.md5
+++ b/test-repo/demo/demo/1.0.0/demo-1.0.0.pom.asc.md5
@@ -1,0 +1,1 @@
+b5f91153fbd3dc8bc29e98c73d46655f  demo-1.0.0.pom.asc

--- a/test-repo/demo/demo/1.0.0/demo-1.0.0.pom.asc.sha1
+++ b/test-repo/demo/demo/1.0.0/demo-1.0.0.pom.asc.sha1
@@ -1,0 +1,1 @@
+d94055dca4e0f2bcc455e278287dcf0e7c4034e1  demo-1.0.0.pom.asc


### PR DESCRIPTION
New attempt to upgrade, following in the footsteps of #59. Experimental is an euphemism :smile: 

I have noticed that the `PomegrateWagonProvider` seemed unnecessary now, and therefore removed it.

All the tests are passing, exception one, reporting the following (maybe some file is actually missing in the demo folder?):

```
FAIL in (deploy-artifacts) (aether_test.clj:347)
Should deploy correct
expected: (= #{"demo-1.0.0.pom.asc.sha1" "demo-1.0.0.pom.sha1" "demo-1.0.0.jar.md5" "demo-1.0.0.pom" "demo-1.0.0.jar.asc.md5" "demo-1.0.0.pom.asc" "demo-1.0.0.jar.asc.sha1" "demo-1.0.0.jar" "demo-1.0.0.jar.sha1" "demo-1.0.0.pom.md5" "demo-1.0.0.jar.asc" "demo-1.0.0.pom.asc.md5"} (set (.list (io/file tmp-remote-repo-dir "demo" "demo" "1.0.0"))))
  actual: (not (= #{"demo-1.0.0.pom.asc.sha1" "demo-1.0.0.pom.sha1" "demo-1.0.0.jar.md5" "demo-1.0.0.pom" "demo-1.0.0.jar.asc.md5" "demo-1.0.0.pom.asc" "demo-1.0.0.jar.asc.sha1" "demo-1.0.0.jar" "demo-1.0.0.jar.sha1" "demo-1.0.0.pom.md5" "demo-1.0.0.jar.asc" "demo-1.0.0.pom.asc.md5"} #{"demo-1.0.0.pom.sha1" "demo-1.0.0.jar.md5" "demo-1.0.0.pom" "demo-1.0.0.pom.asc" "demo-1.0.0.jar" "demo-1.0.0.jar.sha1" "demo-1.0.0.pom.md5" "demo-1.0.0.jar.asc"}))
```

Basically `demo-1.0.0.pom.asc.md5`, `demo-1.0.0.pom.asc.sha1`, etc .... are missing.

Apart from this I am testing this in a maven plugin which resolves and imports dynamically its dependencies, so that part should be covered. I am more worried about the deploy here, but now we have a test bed.

EDIT:
The test probably needs to be adjusted to the new check that aether does: maybe some sort of checksum needs to be at the remote already. I haven't investigated further.