### PR TITLE
Allow repository names to be keywords or symbols or whatever.

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -205,7 +205,7 @@
                        {:url settings}
                        settings)]
     (.build
-     (doto (RemoteRepository$Builder. id
+     (doto (RemoteRepository$Builder. (and id (name id))
                                       (:type settings-map "default")
                                       (str (:url settings-map)))
        (set-policies settings-map)

--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -16,7 +16,7 @@
 
 (def test-remote-repo {"central" "https://repo1.maven.org/maven2/"})
 
-(def test-repo {"test-repo" "file://test-repo"})
+(def test-repo {:test-repo "file://test-repo"})
 (def tmp-remote-repo {"tmp-remote-repo" (str "file://" tmp-remote-repo-dir)})
 
 (defn delete-recursive


### PR DESCRIPTION
This makes it so that `lein change repositories:private dissoc :passphrase` can work.