### PR TITLE
Provide dependency order from Aether API in metadata

### DIFF
--- a/src/main/clojure/cemerick/pomegranate/aether.clj
+++ b/src/main/clojure/cemerick/pomegranate/aether.clj
@@ -457,16 +457,31 @@ kwarg to the repository kwarg.
                              (optional-artifact [:extension "pom"] pom-file)
                              (optional-artifact [] jar-file)))))))
 
+(defn- append-ordered-keys-metadata
+  [coll xs]
+  (and coll
+       (vary-meta coll update-in [:ordered-keys] (comp vec distinct concat) xs)))
+
+(defn- update-graph-with-dep
+  [graph ^DependencyNode node dep]
+  (let [spec (dep-spec dep)
+        child-deps (->> (.getChildren node)
+                        (map #(.getDependency %))
+                        (map dep-spec))]
+    (-> graph
+        (update-in [spec]
+                   (fn [coll more-deps]
+                     (-> coll
+                         (clojure.set/union (set more-deps))
+                         (append-ordered-keys-metadata more-deps)))
+                   child-deps)
+        (append-ordered-keys-metadata [spec]))))
+
 (defn- dependency-graph
   ([node]
     (reduce (fn [g ^DependencyNode n]
               (if-let [dep (.getDependency n)]
-                (update-in g [(dep-spec dep)]
-                           clojure.set/union
-                           (->> (.getChildren n)
-                             (map #(.getDependency %))
-                             (map dep-spec)
-                             set))
+                (update-graph-with-dep g n dep)
                 g))
             {}
             (tree-seq (constantly true)
@@ -810,18 +825,25 @@ kwarg to the repository kwarg.
 (defn resolve-dependencies
   "Same as `resolve-dependencies*`, but returns a graph of dependencies; each
    dependency's metadata contains the source Aether Dependency object, and
-   the dependency's :file on disk.  Please refer to `resolve-dependencies*` for details
-   on usage, or use it if you need access to Aether dependency resolution objects."
+   the dependency's :file on disk.  Due to the graph's being made up of unordered
+   data structures, the order of dependencies is arbitrary; however, ordering
+   information from the Ather DependencyNode object is provided at :ordered-keys
+   in metadata.  Please refer to `resolve-dependencies*` for details on usage, or
+   use it if you need access to Aether dependency resolution objects."
   [& args]
   (-> (apply resolve-dependencies* args)
     .getRoot
     dependency-graph))
 
+(defn- ordered-keys
+  [graph]
+  (or (:ordered-keys (meta graph)) (keys graph)))
+
 (defn dependency-files
   "Given a dependency graph obtained from `resolve-dependencies`, returns a seq of
    files from the dependencies' metadata."
   [graph]
-  (->> graph keys (map (comp :file meta)) (remove nil?)))
+  (->> graph ordered-keys (map (comp :file meta)) (remove nil?)))
 
 (defn- exclusion= [spec1 spec2]
   (let [[dep & opts] (normalize-exclusion-spec spec1)
@@ -870,12 +892,16 @@ kwarg to the repository kwarg.
 (defn dependency-hierarchy
   "Returns a dependency hierarchy based on the provided dependency graph
    (as returned by `resolve-dependencies`) and the coordinates that should
-   be the root(s) of the hierarchy.  Siblings are sorted alphabetically."
+   be the root(s) of the hierarchy.  Siblings are sorted alphabetically,
+   but ordering information originally obtained from the Aether dependency
+   object is provided at :ordered-keys in metadata."
   [root-coordinates dep-graph]
   (let [root-specs (map (comp dep-spec dependency) root-coordinates)
         hierarchy (for [root (filter
                               #(some (fn [root] (within? % root)) root-specs)
-                              (keys dep-graph))]
+                              (ordered-keys dep-graph))]
                     [root (dependency-hierarchy (dep-graph root) dep-graph)])]
     (when (seq hierarchy)
-      (into (sorted-map-by #(apply compare (map coordinate-string %&))) hierarchy))))
+      (append-ordered-keys-metadata
+        (into (sorted-map-by #(apply compare (map coordinate-string %&))) hierarchy)
+        (map first hierarchy)))))


### PR DESCRIPTION
Pomegranate’s Aether API currently does not provide dependency ordering information. This pull request gently enhances the existing API by providing this information in metadata.

The ordering information may be useful for downstream projects, should they wish to make use of it. Since the existing API is unchanged, consumers can opt in and are otherwise not impacted.

The change proposed here would make it possible to resolve technomancy/leiningen#2283 with only a small change (I have tried it already). See that issue for further discussion about the motivation.

This resolves #86.
