### PR TITLE
Fix exception thrown when setting proxy authentication

### DIFF
--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -541,6 +541,23 @@
             ['tester "0.1.0-20120403.012847-1"] nil}
            (aether/dependency-hierarchy coords deps)))))
 
+(deftest make-repository-proxy-settings
+  (let [repo (first test-remote-repo)
+        proxy {:type "https"
+               :host "squid"
+               :port 3128}]
+    (testing "plain proxy"
+      (let [repo-proxy (->> proxy (aether/make-repository repo) .getProxy bean)]
+        (is (= proxy (select-keys repo-proxy (keys proxy))))
+        (is (not (:authentication repo-proxy)))))
+    (testing "authentication"
+      (let [repo-proxy (->> (assoc proxy :username "me" :password "123456")
+                            (aether/make-repository repo)
+                            .getProxy
+                            bean)]
+        (is (= proxy (select-keys repo-proxy (keys proxy))))
+        (is (:authentication repo-proxy))))))
+
 ;; taken from the test suite for the pendantic lib by Nelson Morris
 
 (defn get-versions [name repo]


### PR DESCRIPTION
I looked through @technomancy’s merged pull request #83, and found that
setting proxy authentication now always triggers an exception.

The reason is that `Proxy.setAuthentication` no longer exists –
authentication info must be passed to `Proxy` in the constructor. The
change here fixes this and also cleans up some small things (unused
binding, consistent arg name).

It is possible that this might fix technomancy/leiningen#2151 (just a
guess, I don’t have a proxy to test).
