### PR TITLE
Update Google Maven Central mirror URL

### DIFF
--- a/src/test/clojure/cemerick/pomegranate/aether_test.clj
+++ b/src/test/clojure/cemerick/pomegranate/aether_test.clj
@@ -88,7 +88,7 @@
 (deftest resolve-deps-with-mirror
   (let [deps (aether/resolve-dependencies :repositories {"clojars" "https://clojars.org/repo"}
                                           :coordinates '[[javax.servlet/servlet-api "2.5"]]
-                                          :mirrors {"clojars" {:url "https://maven-central.storage.googleapis.com"}}
+                                          :mirrors {"clojars" {:url "https://maven-central.storage-download.googleapis.com/repos/central/data"}}
                                           :local-repo tmp-local-repo-dir)]
     (is (= 1 (count deps)))
     (is (= (.getAbsolutePath (io/file tmp-dir "local-repo" "javax" "servlet" "servlet-api" "2.5" "servlet-api-2.5.jar"))
@@ -97,7 +97,7 @@
 (deftest resolve-deps-with-wildcard-mirror
   (let [deps (aether/resolve-dependencies :repositories {"clojars" "https://clojars.org/repo"}
                                           :coordinates '[[javax.servlet/servlet-api "2.5"]]
-                                          :mirrors {#".+" {:url "https://maven-central.storage.googleapis.com"}}
+                                          :mirrors {#".+" {:url "https://maven-central.storage-download.googleapis.com/repos/central/data"}}
                                           :local-repo tmp-local-repo-dir)]
     (is (= 1 (count deps)))
     (is (= (.getAbsolutePath (io/file tmp-dir "local-repo" "javax" "servlet" "servlet-api" "2.5" "servlet-api-2.5.jar"))


### PR DESCRIPTION
Unit tests are currently failing because Google’s Maven Central mirror,
which Pomegranate uses for testing mirrors, seems to have moved to a new
location. See
https://storage-download.googleapis.com/maven-central/index.html.

This change updates the URL, making the tests pass again. Thank you!
