### PR TITLE
Fix mentions of Aether to point to Maven-resolver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Non-TLS HTTP repositories are unsupported; using a "bare" HTTP repository now
   requires registering a "wagon" for the insecure transport method (gh-83)
-* Switched/upgraded from Sonatype Aether to Eclipse Aether (gh-80)
+* Switched/upgraded from Sonatype Aether to Maven-resolver (gh-80)
 * Upgraded to Maven `3.5.0` (gh-83)
 * `add-dependencies` now allows you to specify which `ClassLoader` to modify
   (gh-63)

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 [Pomegranate](https://github.com/cemerick/pomegranate) is a library that
 provides:
 
-1. A sane Clojure API for Eclipse
-   [Aether](https://github.com/sonatype/sonatype-aether).
+1. A sane Clojure API for
+   [Maven-resolver](https://maven.apache.org/resolver/) (originally called Aether).
 2. A re-implementation of
    [`add-classpath`](https://clojure.github.com/clojure/clojure.core-api.html#clojure.core/add-classpath)
    (deprecated in Clojure core) that:
 
 * is a little more comprehensive than core's `add-classpath` — it should work as
   expected in more circumstances, and
-* optionally uses Aether to add a Maven artifact (and all of its transitive
+* optionally uses Maven-resolver to add a Maven artifact (and all of its transitive
   dependencies) to your Clojure runtime's classpath dynamically.
 
 Insofar as most useful Clojure libraries have dependencies, any reasonable


### PR DESCRIPTION
Readme and changelog mention still Aether, but the latest release updated Pomegrnate to use Maven-resolver (which replaces Aether): https://github.com/cemerick/pomegranate/pull/83/commits/c4e19981c53311e52f5a8060f34b6d3b69d458bd