### PR TITLE
Update to dynapath 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
           <groupId>org.tcrawley</groupId>
           <artifactId>dynapath</artifactId>
-          <version>0.2.5</version>
+          <version>1.0.0</version>
         </dependency>
         <!-- wagons for dependency resolution -->
         <dependency>


### PR DESCRIPTION
With the advent of restrictions on reflection in Java 9, anything that
loads dynapath will cause a warning to be printed to stdout complaining
about reflective access to `URLClassLoader`, even if no code tries to
modify a `URLClassLoader`:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by dynapath.defaults$fn__1516$fn__1517 (file:/Users/kanwei/.m2/repository/boot/pod/2.7.2/pod-2.7.2.jar) to method java.net.URLClassLoader.addURL(java.net.URL)
WARNING: Please consider reporting this to the maintainers of dynapath.defaults$fn__1516$fn__1517
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

The only change in 1.0.0 is removing the ability to modify
URLClassLoaders. Anyone that was relying on that behavior will either
need to implement `add-classpath-url` from `DynamicClasspath` for
`URLClassLoader`s (which will trigger the above output when used under
Java 9), or use a `clojure.lang.DynamicClassLoader` (or similar) in the
classloader tree as Leiningen does.

See https://github.com/tobias/dynapath/issues/7 for possibly more details.