### PR TITLE
Better way to get classloader to modify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: clojure
-install: mvn install --quiet -DskipTests=true
+install: mvn dependency:resolve
 script: mvn test
+cache:
+  directories:
+  - $HOME/.m2
 jdk:
   - openjdk7
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk10
+matrix:
+  allow_failures:
+    - jdk: openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </scm>
 
     <properties>
-        <clojure.version>1.3.0</clojure.version>
+        <clojure.version>1.9.0</clojure.version>
         <mavenVersion>3.5.0</mavenVersion>
         <resolverVersion>1.0.3</resolverVersion>
         <wagonVersion>2.12</wagonVersion>
@@ -96,7 +96,20 @@
             <version>1.7.22</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nrepl</groupId>
+            <artifactId>nrepl</artifactId>
+            <version>0.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>clojars.org</id>
+            <url>https://repo.clojars.org</url>
+        </repository>
+    </repositories>
 
     <build>
         <resources>

--- a/src/main/clojure/cemerick/pomegranate.clj
+++ b/src/main/clojure/cemerick/pomegranate.clj
@@ -1,5 +1,5 @@
 (ns cemerick.pomegranate
-  (:import (clojure.lang DynamicClassLoader)
+  (:import (clojure.lang DynamicClassLoader RT)
            (java.net URL URLClassLoader))
   (:require [clojure.java.io :as io]
             [cemerick.pomegranate.aether :as aether]
@@ -22,11 +22,17 @@
     (doto (.setAccessible true))
     (.invoke obj (into-array Object args))))
 
+(defn base-classloader []
+  (let [^DynamicClassLoader cl (RT/baseLoader)]
+    (if-let [^DynamicClassLoader parent (.getParent cl)]
+      parent
+      (or cl (.. Thread currentThread getContextClassLoader)))))
+
 (defn classloader-hierarchy
   "Returns a seq of classloaders, with the tip of the hierarchy first.
    Uses the current thread context ClassLoader as the tip ClassLoader
    if one is not provided."
-  ([] (classloader-hierarchy (.. Thread currentThread getContextClassLoader)))
+  ([] (classloader-hierarchy (base-classloader)))
   ([tip]
     (->> tip
       (iterate #(.getParent %))

--- a/src/test/clojure/cemerick/pomegranate_nrepl_test.clj
+++ b/src/test/clojure/cemerick/pomegranate_nrepl_test.clj
@@ -1,0 +1,30 @@
+(ns cemerick.pomegranate-nrepl-test
+  (:require [nrepl.core :as repl]
+            [nrepl.server :as server])
+  (:use clojure.test))
+
+(def port 7888)
+
+(defn nrepl-eval [code]
+  (with-open [conn (repl/connect :port port)]
+    (-> (repl/client conn 1000)
+        (repl/message {:op :eval :code code})
+        repl/response-values)))
+
+;; without this openjdk-7 fail in travis, but there's no exception
+(Thread/setDefaultUncaughtExceptionHandler
+ (reify Thread$UncaughtExceptionHandler
+   (uncaughtException [_ thread ex]
+     (doto (System/err)
+       (.println (str "Thread:" (.getName thread) " raised:" (.toString ex)))
+       (.flush)))))
+
+(deftest add-dependencies-inside-nrepl
+  (let [server (server/start-server :port port)
+        resp (nrepl-eval "(require 'cemerick.pomegranate)
+                          (str (cemerick.pomegranate/add-dependencies :coordinates '[[javax.servlet/servlet-api \"2.5\"]]))
+                          (str (import 'javax.servlet.http.HttpServlet))")]
+    (is (= resp [nil
+                 "{[javax.servlet/servlet-api \"2.5\"] nil}"
+                 "class javax.servlet.http.HttpServlet"])) ;; nil means class not loaded
+    (server/stop-server server)))


### PR DESCRIPTION
This PR makes workflow in nrepl-based repls great again.
Troubles are bound to changes related classloaders of java-9/dynapath-1.0/clojure-1.7.
PR allows proper classloading of deps, which are installed in repl itself. 

I think, this should fix https://github.com/cemerick/pomegranate/issues/94
*NOTE* This issue is nrepl-specific (actually multiple-main/repl-specific). clojure-cli works ok with current pomergranate-1.0

So, this looks like a hack in favor of nrepl, please suggest a better way. This way works for me in any setup: clojure-cli or lein-repl. Attached test fails on current master.

@cemerick I carefully followed the story about nrepl, various threads on google group, clojure jira related classloading: about too many DCL (DynamicClassLoader), thoughts about replace clojure.main/repl with in-house impl. IMO currently almost everything is ok, except need for this hack, besides, leave `clojure.main/repl` in nrepl, please :)

I spend quite lot of time choosing what to fix :) pomegranate, nrepl or even clojure
btw, I patched clojure as well: https://gist.github.com/razum2um/af4b74a76003458150cbfdd0e011d018
interested in your opinion about that patch as well, but it's not required to get add-dependencies working, this clojure-patch fixes this https://dev.clojure.org/jira/browse/NREPL-36

*NOTE* this PR has troubles with jdk-7 on travis, see comments