### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cemerick</groupId>
     <artifactId>pomegranate</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>pomegranate</name>
     <description />
     <url>http://github.com/cemerick/pomegranate</url>
@@ -30,9 +30,9 @@
 
     <properties>
         <clojure.version>1.3.0</clojure.version>
-        <mavenVersion>3.5.0</mavenVersion>
+        <mavenVersion>3.5.3</mavenVersion>
         <resolverVersion>1.0.3</resolverVersion>
-        <wagonVersion>2.12</wagonVersion>
+        <wagonVersion>3.0.0</wagonVersion>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Since this involves a major version upgrade of maven-wagon, I also bumped the SNAPSHOT version by minor.

Fixes #101.

I ran the tests locally and didn't see any breakage, so maybe this is less bad than I feared and the APIs are compatible?