### PR TITLE
Pick up fix for CVE-2018-10237

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.clojure</groupId>
         <artifactId>pom.contrib</artifactId>
-        <version>0.0.20</version>
+        <version>0.2.2</version>
     </parent>
 
     <developers>
@@ -30,9 +30,9 @@
 
     <properties>
         <clojure.version>1.3.0</clojure.version>
-        <mavenVersion>3.5.3</mavenVersion>
-        <resolverVersion>1.0.3</resolverVersion>
-        <wagonVersion>3.0.0</wagonVersion>
+        <mavenVersion>3.6.0</mavenVersion>
+        <resolverVersion>1.3.3</resolverVersion>
+        <wagonVersion>3.3.2</wagonVersion>
     </properties>
 
     <dependencies>
@@ -88,12 +88,12 @@
         <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
-          <version>4.5.3</version>
+          <version>4.5.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.22</version>
+            <version>1.7.26</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This will pick up a fix for CVE-2018-10237 in `com.google.guava`, and
bring the rest of the dependencies up-to-date as a bonus.